### PR TITLE
[major] expose ESM under module

### DIFF
--- a/context.js
+++ b/context.js
@@ -1,5 +1,5 @@
-const addhoc = require('addhoc').default;
-const React = require('react');
+import addhoc from 'addhoc';
+import React from 'react';
 
 /**
  * The custom context.
@@ -24,7 +24,7 @@ const withConsumer = addhoc(getWrappedComponent => (
   </Context.Consumer>
 ), 'withValidationContext');
 
-module.exports = {
+export {
   withConsumer,
   Context
 };

--- a/index.js
+++ b/index.js
@@ -1,10 +1,13 @@
-const { withConsumer, Context } = require('./context');
-const Validates = require('./validates');
-const Validate = require('./validate');
+import { withConsumer, Context } from './context';
+import Validates from './validates';
+import Validate from './validate';
 
-module.exports = {
-  Validates: withConsumer(Validates),
-  Validate: withConsumer(Validate),
+const ValidatesConsumer = withConsumer(Validates);
+const ValidateConsumer = withConsumer(Validate);
+
+export {
+  ValidatesConsumer as Validates,
+  ValidateConsumer as Validate,
   withConsumer,
   Context
 };

--- a/validate.js
+++ b/validate.js
@@ -1,7 +1,7 @@
-const Validates = require('./validates');
-const { Context } = require('./context');
-const PropTypes = require('prop-types');
-const React = require('react');
+import Validates from './validates';
+import { Context }  from './context';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * This library revolves around the idea of "validity". A component can have one of the following validities:
@@ -160,4 +160,4 @@ if (Validates.propTypes) {
 //
 // Expose the interface.
 //
-module.exports = Validate;
+export default Validate;

--- a/validates.js
+++ b/validates.js
@@ -1,5 +1,5 @@
-const PropTypes = require('prop-types');
-const { Component } = require('react');
+import PropTypes from 'prop-types';
+import { Component } from 'react';
 
 function noop() {}
 
@@ -122,4 +122,4 @@ Validates.propTypes = {
 //
 // Expose the interface.
 //
-module.exports = Validates;
+export default Validates;


### PR DESCRIPTION
Internal we have some modules using this source code as if it was ESM.
Build tools expect ESM under `module` whether that is technically correct or not.

Should be released as 6.0.0 to prevent issues with consuming packages.